### PR TITLE
Force _iDisplayStart and _iDisplayLength to numeric

### DIFF
--- a/pagination/input.js
+++ b/pagination/input.js
@@ -41,10 +41,14 @@
 	}
 
 	function calcCurrentPage(oSettings) {
+		oSettings._iDisplayStart = parseInt(oSettings._iDisplayStart);
+		oSettings._iDisplayLength = parseInt(oSettings._iDisplayLength);
 		return Math.ceil(oSettings._iDisplayStart / oSettings._iDisplayLength) + 1;
 	}
 
 	function calcPages(oSettings) {
+		oSettings._iDisplayStart = parseInt(oSettings._iDisplayStart);
+		oSettings._iDisplayLength = parseInt(oSettings._iDisplayLength);
 		return Math.ceil(oSettings.fnRecordsDisplay() / oSettings._iDisplayLength);
 	}
 


### PR DESCRIPTION
I'm using the excellent Input.js plugin which works much better for large server-based datasets than DataTables' built-in pagination.  But under certain circumstances (which I haven't quite nailed down), when clicking the Next button, the new page's starting position gets calculated not as the sum of two integers-- the previous start plus the page length, but rather as the concatenation of two _strings_, causing the pagination to go haywire.  My proposed changes in calcPages() and calcCurrentPage() force oSettings._iDisplayStart and oSettings._iDisplayLength to be typed as integers before calculating new page starting position, thus fixing the issue.

Example of the issue being fixed:

Initialize DataTables with 25 rows per page and 600 rows total - these AJAX params are sent to the data server:

```
- start:0
- length:25
```

Then click "next page" button, now these are sent to server.  Note that "25" was **appended** to previous start ("0") for new start of "025":

```
- start:"025"
- length:"25"
```

Clicking the Next button again will put us at "02525" which is beyond the end of the data set, even though the input still shows us at page 2.  After that, clicking the Next button just loads page 2 over and over.

It may be better to address this string-vs-integer issue upstream in the DataTables main code, I'm not sure.  This change fixed it for me.
